### PR TITLE
Additional filtering allows to obtain IDs of Windows Server 2019 updates with a Preview tag

### DIFF
--- a/Get-LatestWindowsRollup/Get-LatestWindowsRollup.ps1
+++ b/Get-LatestWindowsRollup/Get-LatestWindowsRollup.ps1
@@ -67,6 +67,7 @@ function Get-LatestWindowsRollup {
         $SupportKBUriTemplate = 'https://support.microsoft.com/app/content/api/content/help/en-us/{0}'
         $PreviewRollupRegEx = ('[A-Za-z]+ \d{{1,2}}, \d{{4}}[{0}-]KB\d+ \(Preview of Monthly Rollup\)' -f [char](8212)) # Somehow PS5.1 cannot process the "—" character in strings correctly.
         $SecurityOnlyRegEx = ('[A-Za-z]+ \d{{1,2}}, \d{{4}}[{0}-]KB\d+ \(Security-only update\)' -f [char](8212))
+        $PreviewRegEx = ('\w+ \d{{1,2}}, \d{{4}}[{0}-]KB\d+ \(\w{{2}} \w{{5}} \d+\.\d+\) Preview$' -f [char](8212))
         $OSDefs = @{
             '2012'   = @{
                 KB                    = '4009471'
@@ -96,6 +97,7 @@ function Get-LatestWindowsRollup {
             }
             '2019'   = @{
                 KB = '4464619'
+                SeveralTypesAvailable = $true
             }
         }
 
@@ -130,7 +132,7 @@ function Get-LatestWindowsRollup {
                                     $SecurityOnlyID = $UpdateRecordProcessed.ID
                                 }
                             }
-                            elseif ($UpdateRecordProcessed.Title -match $PreviewRollupRegEx) {
+                            elseif ($UpdateRecordProcessed.Title -match $PreviewRollupRegEx -or $UpdateRecordProcessed.Title -match $PreviewRegEx) {
                                 if (-not $RollupPreviewID) {
                                     $RollupPreviewID = $UpdateRecordProcessed.ID
                                 }
@@ -152,7 +154,7 @@ function Get-LatestWindowsRollup {
                     }
                     Default {
                         foreach ($UpdateRecordProcessed in $UpdateListProcessedSorted) {
-                            if ($UpdateRecordProcessed.Title -notmatch $PreviewRollupRegEx -and $UpdateRecordProcessed.Title -notmatch $SecurityOnlyRegEx) {
+                            if ($UpdateRecordProcessed.Title -notmatch $PreviewRollupRegEx -and $UpdateRecordProcessed.Title -notmatch $SecurityOnlyRegEx -and $UpdateRecordProcessed.Title -notmatch $PreviewRegEx) {
                                 $UpdateRecordProcessed.ID
                                 break
                             }

--- a/Get-LatestWindowsRollup/Get-LatestWindowsRollup.ps1
+++ b/Get-LatestWindowsRollup/Get-LatestWindowsRollup.ps1
@@ -67,7 +67,7 @@ function Get-LatestWindowsRollup {
         $SupportKBUriTemplate = 'https://support.microsoft.com/app/content/api/content/help/en-us/{0}'
         $PreviewRollupRegEx = ('[A-Za-z]+ \d{{1,2}}, \d{{4}}[{0}-]KB\d+ \(Preview of Monthly Rollup\)' -f [char](8212)) # Somehow PS5.1 cannot process the "—" character in strings correctly.
         $SecurityOnlyRegEx = ('[A-Za-z]+ \d{{1,2}}, \d{{4}}[{0}-]KB\d+ \(Security-only update\)' -f [char](8212))
-        $PreviewRegEx = ('\w+ \d{{1,2}}, \d{{4}}[{0}-]KB\d+ \(\w{{2}} \w{{5}} \d+\.\d+\) Preview$' -f [char](8212))
+        $PreviewRegEx = ('[A-Za-z]+ \d{{1,2}}, \d{{4}}[{0}-]KB\d+ \(\[A-Za-z]{{2}} \[A-Za-z]{{5}} \d+\.\d+\) Preview$' -f [char](8212))
         $OSDefs = @{
             '2012'   = @{
                 KB                    = '4009471'


### PR DESCRIPTION
When using Get-LatestWindowsRollup script, it was noticed that updates with the preview tag for the windows server 2012r2 operating system are filtered, but such updates are not filtered for windows server 2019. This pull request changes allows to filter updates for windows server 2019 with the preview tag in the same way as it doing for the windows server 2012r2.